### PR TITLE
Fix pre_eq_reduce

### DIFF
--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -184,14 +184,8 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
         if elem.is_in_the_normal_form {
             return Ok(());
         }
-
-        let log = overhead!(elem.num_of_additions_over_normal_form + BaseField::one()) + 1;
-
-        if BaseField::size_in_bits() > params.bits_per_limb + log + 1 {
-            Ok(())
-        } else {
-            Self::reduce(elem)
-        }
+        
+        Self::reduce(elem)
     }
 
     /// Group and check equality

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -178,13 +178,10 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
     pub fn pre_eq_reduce(
         elem: &mut AllocatedNonNativeFieldVar<TargetField, BaseField>,
     ) -> R1CSResult<()> {
-        let cs = elem.cs.clone();
-        let params = get_params::<TargetField, BaseField>(&cs);
-
         if elem.is_in_the_normal_form {
             return Ok(());
         }
-        
+
         Self::reduce(elem)
     }
 


### PR DESCRIPTION
The pre_eq_reduce should directly reduce the value to the normal form rather than checking it.