### PR TITLE
Fix the incorrect padding

### DIFF
--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -495,8 +495,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBytesGadget<BaseField>
 {
     #[tracing::instrument(target = "r1cs")]
     fn to_bytes(&self) -> R1CSResult<Vec<UInt8<BaseField>>> {
-        let mut bits = self.to_bits_le()?;
-        bits.reverse();
+        let bits = self.to_bits_le()?;
 
         let mut bytes = Vec::<UInt8<BaseField>>::new();
         bits.chunks(8).for_each(|bits_per_byte| {
@@ -504,7 +503,6 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBytesGadget<BaseField>
             if bits_per_byte.len() < 8 {
                 bits_per_byte.resize_with(8, || Boolean::<BaseField>::constant(false));
             }
-            bits_per_byte.reverse();
 
             bytes.push(UInt8::<BaseField>::from_bits_le(&bits_per_byte));
         });


### PR DESCRIPTION
As @Will-Lin4 discovers, there are more problems with the ToBytesGadget.
In particular, it pads at the end of the lowest bits.

This PR removes the two reversions so that now the padding is to the highest bits.