### PR TITLE
Supply a test for ToBytesGadget

### DIFF
--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -542,15 +542,6 @@ macro_rules! nonnative_test_individual {
             #[test]
             fn [<$test_method _ $test_name:lower>]() {
                 let rng = &mut ark_std::test_rng();
-                /*{
-                    let cs = ConstraintSystem::<$test_base_field>::new();
-                    let cs_ref = ConstraintSystemRef::new(cs);
-                    HitRate::init(&cs_ref);
-                    $test_method::<$test_target_field, $test_base_field, _>(cs_ref.clone(), rng);
-                    assert!(cs_ref.is_satisfied().unwrap());
-                    println!("In test {} for {}: ", stringify!($test_method), stringify!($test_name));
-                    HitRate::print(&cs_ref);
-                }*/
 
                 for _ in 0..NUM_REPETITIONS {
                     let cs = ConstraintSystem::<$test_base_field>::new_ref();

--- a/tests/to_bytes_test.rs
+++ b/tests/to_bytes_test.rs
@@ -1,0 +1,35 @@
+use ark_ec::PairingEngine;
+use ark_mnt4_298::MNT4_298;
+use ark_mnt6_298::MNT6_298;
+use ark_nonnative_field::NonNativeFieldVar;
+use ark_r1cs_std::alloc::AllocVar;
+use ark_r1cs_std::{R1CSVar, ToBytesGadget};
+use ark_relations::r1cs::ConstraintSystem;
+
+#[test]
+fn to_bytes_test() {
+    let cs = ConstraintSystem::<<MNT6_298 as PairingEngine>::Fr>::new_ref();
+
+    let target_test_elem = <MNT4_298 as PairingEngine>::Fr::from(123456u128);
+    let target_test_gadget = NonNativeFieldVar::<
+        <MNT4_298 as PairingEngine>::Fr,
+        <MNT6_298 as PairingEngine>::Fr,
+    >::new_witness(cs, || Ok(target_test_elem))
+    .unwrap();
+
+    let target_to_bytes: Vec<u8> = target_test_gadget
+        .to_bytes()
+        .unwrap()
+        .iter()
+        .map(|v| v.value().unwrap())
+        .collect();
+
+    // 123456 = 65536 + 226 * 256 + 64
+    assert_eq!(target_to_bytes[0], 64);
+    assert_eq!(target_to_bytes[1], 226);
+    assert_eq!(target_to_bytes[2], 1);
+
+    for byte in target_to_bytes.iter().skip(3) {
+        assert_eq!(*byte, 0);
+    }
+}


### PR DESCRIPTION
This is related to #25 and #24.

Several components of nonnative have never been used or tested in the upstream or here. As is discovered, the ToBytesGadget did not behave as desired.

This PR supplies a test for ToBytesGadget. More tests for the rest of the components are upcoming.