### PR TITLE
Fix the implementation of ToBitsGadget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ num-integer = { version = "0.1.44", default-features = false }
 
 [dev-dependencies]
 paste = "1.0"
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", features = ["curve"], default-features = false  }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves", features = ["curve"], default-features = false  }
 ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves", features = ["curve"], default-features = false  }
 ark-mnt4-753 = { git = "https://github.com/arkworks-rs/curves", features = ["curve"], default-features = false  }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,7 +15,7 @@ fn get_density<BaseField: PrimeField>(cs: &ConstraintSystemRef<BaseField>) -> us
         ConstraintSystemRef::CS(r) => {
             let mut cs_bak = r.borrow().clone();
 
-            cs_bak.outline_lcs();
+            cs_bak.reduce_constraint_weight();
             let matrices = cs_bak.to_matrices().unwrap();
 
             matrices.a_num_non_zero + matrices.b_num_non_zero + matrices.c_num_non_zero

--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -484,7 +484,16 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBitsGadget<BaseField>
             )?);
         }
         bits.reverse();
-        Boolean::enforce_in_field_le(&bits)?;
+
+        let mut b = TargetField::characteristic().to_vec();
+        assert_eq!(b[0] % 2, 1);
+        b[0] -= 1; // This works, because the LSB is one, so there's no borrows.
+        let run = Boolean::<BaseField>::enforce_smaller_or_equal_than_le(&bits, b)?;
+
+        // We should always end in a "run" of zeros, because
+        // the characteristic is an odd prime. So, this should
+        // be empty.
+        assert!(run.is_empty());
 
         Ok(bits)
     }

--- a/src/nonnative_field_var.rs
+++ b/src/nonnative_field_var.rs
@@ -1,5 +1,5 @@
 use crate::{AllocatedNonNativeFieldVar, NonNativeFieldMulResultVar};
-use ark_ff::to_bytes;
+use ark_ff::{to_bytes, FpParameters};
 use ark_ff::PrimeField;
 use ark_r1cs_std::boolean::Boolean;
 use ark_r1cs_std::fields::fp::FpVar;
@@ -295,7 +295,8 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBitsGadget<BaseField>
     fn to_non_unique_bits_le(&self) -> R1CSResult<Vec<Boolean<BaseField>>> {
         use ark_ff::BitIteratorLE;
         match self {
-            Self::Constant(c) => Ok(BitIteratorLE::without_trailing_zeros(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
+                .take((TargetField::Params::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
             Self::Var(v) => v.to_non_unique_bits_le(),

--- a/src/nonnative_field_var.rs
+++ b/src/nonnative_field_var.rs
@@ -1,6 +1,6 @@
 use crate::{AllocatedNonNativeFieldVar, NonNativeFieldMulResultVar};
-use ark_ff::{to_bytes, FpParameters};
 use ark_ff::PrimeField;
+use ark_ff::{to_bytes, FpParameters};
 use ark_r1cs_std::boolean::Boolean;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_r1cs_std::fields::FieldVar;

--- a/tests/to_bytes_test.rs
+++ b/tests/to_bytes_test.rs
@@ -3,8 +3,9 @@ use ark_mnt4_298::MNT4_298;
 use ark_mnt6_298::MNT6_298;
 use ark_nonnative_field::NonNativeFieldVar;
 use ark_r1cs_std::alloc::AllocVar;
-use ark_r1cs_std::{R1CSVar, ToBytesGadget};
+use ark_r1cs_std::{R1CSVar, ToBytesGadget, ToBitsGadget};
 use ark_relations::r1cs::ConstraintSystem;
+use ark_ff::Zero;
 
 #[test]
 fn to_bytes_test() {
@@ -32,4 +33,16 @@ fn to_bytes_test() {
     for byte in target_to_bytes.iter().skip(3) {
         assert_eq!(*byte, 0);
     }
+}
+
+#[test]
+fn to_bits_test() {
+    type F = ark_bls12_377::Fr;
+    type CF = ark_bls12_377::Fq;
+
+    let cs = ConstraintSystem::<CF>::new_ref();
+    let f = F::zero();
+
+    let f_var = NonNativeFieldVar::<F, CF>::new_input(cs.clone(), || Ok(f)).unwrap();
+    f_var.to_bits_le().unwrap();
 }

--- a/tests/to_bytes_test.rs
+++ b/tests/to_bytes_test.rs
@@ -1,11 +1,11 @@
 use ark_ec::PairingEngine;
+use ark_ff::Zero;
 use ark_mnt4_298::MNT4_298;
 use ark_mnt6_298::MNT6_298;
 use ark_nonnative_field::NonNativeFieldVar;
 use ark_r1cs_std::alloc::AllocVar;
-use ark_r1cs_std::{R1CSVar, ToBytesGadget, ToBitsGadget};
+use ark_r1cs_std::{R1CSVar, ToBitsGadget, ToBytesGadget};
 use ark_relations::r1cs::ConstraintSystem;
-use ark_ff::Zero;
 
 #[test]
 fn to_bytes_test() {


### PR DESCRIPTION
cc'ed @Will-Lin4 

There are two problems in the current implementation of ToBitsGadget

1. The output of `to_bits` for a constant nonnative field is not of constant length. This is related to https://github.com/arkworks-rs/r1cs-std/pull/12. Thus, we follow the upstream change and make this output constant length.
2. The `enforce_in_field_le` should be done against the `TargetField` but currently, the implementation is for `BaseField`. This is unsound. And this has caused an error that `to_bits_le` over curves whose Fr and Fq are very different (e.g., BLS).

This PR fixes these problems and adds a test for it.