### PR TITLE
Fix a number of problems that block Pallas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves", features = ["cur
 ark-mnt4-753 = { git = "https://github.com/arkworks-rs/curves", features = ["curve"], default-features = false  }
 ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false  }
 ark-mnt6-753 = { git = "https://github.com/arkworks-rs/curves", default-features = false  }
+ark-pallas = { git = "https://github.com/arkworks-rs/curves", features = ["curve"],  default-features = false  }
 
 [features]
 default = []

--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -41,8 +41,12 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
         let params = get_params(TargetField::size_in_bits(), BaseField::size_in_bits());
 
         let mut base_repr: <TargetField as PrimeField>::BigInt = TargetField::one().into_repr();
-        base_repr.muln(params.bits_per_limb as u32);
-        let base: TargetField = TargetField::from_repr(base_repr).unwrap();
+
+        // Convert 2^{(params.bits_per_limb - 1)} into the TargetField and then double the base
+        // This is because 2^{(params.bits_per_limb)} might indeed be larger than the target field's prime.
+        base_repr.muln((params.bits_per_limb - 1) as u32);
+        let mut base: TargetField = TargetField::from_repr(base_repr).unwrap();
+        base = base + &base;
 
         let mut result = TargetField::zero();
         let mut power = TargetField::one();

--- a/src/params.rs
+++ b/src/params.rs
@@ -38,9 +38,10 @@ pub const fn find_parameters(
     let mut min_cost_num_of_limbs = 0usize;
 
     let surfeit = 10;
-
-    let max_limb_size = (base_field_prime_length - 1 - surfeit - 1) / 2 - 1;
-
+    let mut max_limb_size = (base_field_prime_length - 1 - surfeit - 1) / 2 - 1;
+    if max_limb_size > target_field_prime_bit_length {
+        max_limb_size = target_field_prime_bit_length;
+    }
     let mut limb_size = 1;
 
     while limb_size <= max_limb_size {

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -203,13 +203,17 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
         right: &[FpVar<BaseField>],
     ) -> R1CSResult<()> {
         let cs = left.cs().or(right.cs());
-
         let zero = FpVar::<BaseField>::zero();
 
         let mut limb_pairs = Vec::<(FpVar<BaseField>, FpVar<BaseField>)>::new();
-        let num_limb_in_a_group =
-            (BaseField::size_in_bits() - 1 - surfeit - 1 - 1 - (bits_per_limb - shift_per_limb))
-                / shift_per_limb;
+        let num_limb_in_a_group = (BaseField::size_in_bits()
+            - 1
+            - surfeit
+            - 1
+            - 1
+            - 1
+            - (bits_per_limb - shift_per_limb))
+            / shift_per_limb;
 
         let shift_array = {
             let mut array = Vec::new();

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -684,3 +684,15 @@ nonnative_test!(
     <MNT6_753 as PairingEngine>::Fr,
     <MNT4_298 as PairingEngine>::Fr
 );
+nonnative_test!(
+    PallasFrMNT6Fr,
+    ark_pallas::Fr,
+    <MNT6_753 as PairingEngine>::Fr
+);
+nonnative_test!(
+    MNT6FrPallasFr,
+    <MNT6_753 as PairingEngine>::Fr,
+    ark_pallas::Fr
+);
+nonnative_test!(PallasFqFr, ark_pallas::Fq, ark_pallas::Fr);
+nonnative_test!(PallasFrFq, ark_pallas::Fr, ark_pallas::Fq);


### PR DESCRIPTION
This closes #32.

There are two problems in the current implementation. And coincidentally, nonnative arithmetic with Pallas triggers both of them.

The first problem is that, if the limb size equals the size of the target field (which happens when the base field is very large), the allocation of 2^{limb_size} would fail in the target field. This is now fixed by allocating 2^{limb_size-1} and then doubling it.

The second problem is that, the reduction algorithm does not leave sufficient space that accounts for a potential additional bit caused by adding the pad with the value. This is fixed by asking the reduction algorithm to leave one more bit.

Tests for Pallas have been added to the test file and will now be checked by the CI.