### PR TITLE
Use ark_std::rand instead of rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ debug-assertions = false
 ################################# Dependencies ################################
 
 [dependencies]
-rand = { version = "0.7", default-features = false }
 derivative = { version = "2", features = [ "use_core" ] }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@ use ark_relations::{
     ns,
     r1cs::{ConstraintSystem, ConstraintSystemRef, OptimizationGoal},
 };
-use rand::RngCore;
+use ark_std::rand::RngCore;
 
 const NUM_REPETITIONS: usize = 1;
 

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -9,7 +9,7 @@ use ark_mnt6_753::MNT6_753;
 use ark_nonnative_field::NonNativeFieldVar;
 use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::FieldVar, R1CSVar};
 use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
-use rand::RngCore;
+use ark_std::rand::RngCore;
 
 #[cfg(not(ci))]
 const NUM_REPETITIONS: usize = 100;


### PR DESCRIPTION
As the title. This is part of a larger plan to move the dependency on rand to ark_std::rand and bump up the rand's version together.