### PR TITLE
Add padding to allocated nonnative `to_bytes`

### DIFF
--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -577,18 +577,13 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBytesGadget<BaseField>
 {
     #[tracing::instrument(target = "r1cs")]
     fn to_bytes(&self) -> R1CSResult<Vec<UInt8<BaseField>>> {
-        let bits = self.to_bits_le()?;
+        let mut bits = self.to_bits_le()?;
 
-        let mut bytes = Vec::<UInt8<BaseField>>::new();
-        bits.chunks(8).for_each(|bits_per_byte| {
-            let mut bits_per_byte: Vec<Boolean<BaseField>> = bits_per_byte.to_vec();
-            if bits_per_byte.len() < 8 {
-                bits_per_byte.resize_with(8, || Boolean::<BaseField>::constant(false));
-            }
+        let num_bits = TargetField::BigInt::NUM_LIMBS * 64;
+        assert!(bits.len() <= num_bits);
+        bits.resize_with(num_bits, || Boolean::constant(false));
 
-            bytes.push(UInt8::<BaseField>::from_bits_le(&bits_per_byte));
-        });
-
+        let bytes = bits.chunks(8).map(UInt8::from_bits_le).collect();
         Ok(bytes)
     }
 }

--- a/tests/to_bytes_test.rs
+++ b/tests/to_bytes_test.rs
@@ -1,5 +1,5 @@
 use ark_ec::PairingEngine;
-use ark_ff::Zero;
+use ark_ff::{to_bytes, Zero};
 use ark_mnt4_298::MNT4_298;
 use ark_mnt6_298::MNT6_298;
 use ark_nonnative_field::NonNativeFieldVar;
@@ -33,6 +33,8 @@ fn to_bytes_test() {
     for byte in target_to_bytes.iter().skip(3) {
         assert_eq!(*byte, 0);
     }
+
+    assert_eq!(to_bytes!(target_test_elem).unwrap(), target_to_bytes);
 }
 
 #[test]


### PR DESCRIPTION
Pads allocated nonnative to_bytes to the nearest 64 bits to output the same number of bytes as the native counterpart.