### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
+v                               ✰  Thanks for creating a PR! ✰
+v    Before hitting that submit button please review the checkboxes.
+v    If a checkbox is n/a - please still include it but + a little note why
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+
+## Description
+
+<!-- Add a description of the changes that this PR introduces and the files that
+are the most critical to review.
+-->
+
+closes: #XXXX
+
+---
+
+Before we can merge this PR, please make sure that all the following items have been
+checked off. If any of the checklist items are not applicable, please leave them but
+write a little note why.
+
+- [ ] Targeted PR against correct branch (master)
+- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
+- [ ] Wrote unit tests
+- [ ] Updated relevant documentation in the code
+- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
+- [ ] Re-reviewed `Files changed` in the Github PR explorer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# CHANGELOG
+
+## Pending
+
+### Breaking changes
+
+### Features
+
+### Improvements
+
+### Bug fixes
+
+## v0.3.0
+
+### Breaking changes
+
+- [\#43](https://github.com/arkworks-rs/nonnative/pull/43) Add padding to allocated nonnative element's `to_bytes`.
+
+### Features
+
+### Improvements
+
+### Bug fixes
+
+## v0.2.0 (Initial release of ark-nonnative)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-nonnative-field"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Weikeng Chen",
     "Alessandro Chiesa",
@@ -41,11 +41,11 @@ derivative = { version = "2", features = [ "use_core" ] }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 
-ark-ff = { version = "^0.2.0", default-features = false }
-ark-ec = { version = "^0.2.0", default-features = false }
-ark-std = { version = "^0.2.0", default-features = false }
-ark-relations = { version = "^0.2.0", default-features = false }
-ark-r1cs-std = { version = "^0.2.0", default-features = false  }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-ec = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
+ark-relations = { version = "^0.3.0", default-features = false }
+ark-r1cs-std = { version = "^0.3.0", default-features = false  }
 
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4.0", default-features = false }
@@ -53,13 +53,13 @@ num-integer = { version = "0.1.44", default-features = false }
 
 [dev-dependencies]
 paste = "1.0"
-ark-bls12-377 = { version = "^0.2.0", features = ["curve"], default-features = false  }
-ark-bls12-381 = { version = "^0.2.0", features = ["curve"], default-features = false  }
-ark-mnt4-298 = { version = "^0.2.0", features = ["curve"], default-features = false  }
-ark-mnt4-753 = { version = "^0.2.0", features = ["curve"], default-features = false  }
-ark-mnt6-298 = { version = "^0.2.0", default-features = false  }
-ark-mnt6-753 = { version = "^0.2.0", default-features = false  }
-ark-pallas = { version = "^0.2.0", features = ["curve"],  default-features = false  }
+ark-bls12-377 = { version = "^0.3.0", features = ["curve"], default-features = false  }
+ark-bls12-381 = { version = "^0.3.0", features = ["curve"], default-features = false  }
+ark-mnt4-298 = { version = "^0.3.0", features = ["curve"], default-features = false  }
+ark-mnt4-753 = { version = "^0.3.0", features = ["curve"], default-features = false  }
+ark-mnt6-298 = { version = "^0.3.0", default-features = false  }
+ark-mnt6-753 = { version = "^0.3.0", default-features = false  }
+ark-pallas = { version = "^0.3.0", features = ["curve"],  default-features = false  }
 
 [features]
 default = []


### PR DESCRIPTION
This PR prepares `ark-nonnative` for the release of v0.3.0.