### PR TITLE
Get bits from non-native allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [\#45](https://github.com/arkworks-rs/nonnative/pull/45) Add `new_witness_alloc_le_bits` which returns bits used for allocation.
+
 ### Improvements
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Features
 
-- [\#45](https://github.com/arkworks-rs/nonnative/pull/45) Add `new_witness_alloc_le_bits` which returns bits used for allocation.
+- [\#45](https://github.com/arkworks-rs/nonnative/pull/45) Add `new_witness_with_le_bits` which returns the bits used during variable allocation.
 
 ### Improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-nonnative-field"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Weikeng Chen",
     "Alessandro Chiesa",

--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -582,9 +582,10 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
     /// less than the modulus.
     ///
     /// Returns the bits of the element, in little-endian form
-    fn enforce_in_range(&self,
+    fn enforce_in_range(
+        &self,
         cs: impl Into<Namespace<BaseField>>,
-        ) -> R1CSResult<Vec<Boolean<BaseField>>> {
+    ) -> R1CSResult<Vec<Boolean<BaseField>>> {
         let ns = cs.into();
         let cs = ns.cs();
         let optimization_type = match cs.optimization_goal() {

--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -855,7 +855,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocVar<TargetField, BaseF
     ) -> R1CSResult<Self> {
         let ns = cs.into();
         let cs = ns.cs();
-        let this = Self::new_variable_unchecked(ns!(cs, "alloc"), f, AllocationMode::Witness)?;
+        let this = Self::new_variable_unchecked(ns!(cs, "alloc"), f, mode)?;
         if mode == AllocationMode::Witness {
             this.enforce_in_range(ns!(cs, "bits"))?;
         }

--- a/src/allocated_nonnative_field_var.rs
+++ b/src/allocated_nonnative_field_var.rs
@@ -582,16 +582,21 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
 
         if mode == AllocationMode::Witness {
             for limb in limbs.iter().rev().take(params.num_limbs - 1) {
-                bits.extend(Reducer::<TargetField, BaseField>::limb_to_bits(
-                    limb,
-                    params.bits_per_limb,
-                )?.into_iter().rev());
+                bits.extend(
+                    Reducer::<TargetField, BaseField>::limb_to_bits(limb, params.bits_per_limb)?
+                        .into_iter()
+                        .rev(),
+                );
             }
 
-            bits.extend(Reducer::<TargetField, BaseField>::limb_to_bits(
-                &limbs[0],
-                TargetField::size_in_bits() - (params.num_limbs - 1) * params.bits_per_limb,
-            )?.into_iter().rev());
+            bits.extend(
+                Reducer::<TargetField, BaseField>::limb_to_bits(
+                    &limbs[0],
+                    TargetField::size_in_bits() - (params.num_limbs - 1) * params.bits_per_limb,
+                )?
+                .into_iter()
+                .rev(),
+            );
         }
 
         Ok((

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -6,13 +6,8 @@ use ark_mnt4_753::MNT4_753;
 use ark_mnt6_298::MNT6_298;
 use ark_mnt6_753::MNT6_753;
 
-use ark_nonnative_field::{AllocatedNonNativeFieldVar, NonNativeFieldVar};
-use ark_r1cs_std::{
-    alloc::{AllocVar, AllocationMode},
-    eq::EqGadget,
-    fields::FieldVar,
-    R1CSVar,
-};
+use ark_nonnative_field::{NonNativeFieldVar, AllocatedNonNativeFieldVar};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::FieldVar, R1CSVar};
 use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
 use ark_std::rand::RngCore;
 
@@ -44,13 +39,11 @@ fn allocation_test<TargetField: PrimeField, BaseField: PrimeField, R: RngCore>(
         "allocated value does not equal the expected value"
     );
 
-    let (_a, a_bits) =
-        AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_variable_alloc_le_bits(
-            ark_relations::ns!(cs, "alloc a2"),
-            || Ok(a_native),
-            AllocationMode::Witness,
-        )
-        .unwrap();
+    let (_a, a_bits) = AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_witness_with_le_bits(
+        ark_relations::ns!(cs, "alloc a2"),
+        || Ok(a_native),
+    )
+    .unwrap();
 
     let a_bits_actual: Vec<bool> = a_bits.into_iter().map(|b| b.value().unwrap()).collect();
     let mut a_bits_expected = a_native.into_repr().to_bits_le();

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -6,7 +6,7 @@ use ark_mnt4_753::MNT4_753;
 use ark_mnt6_298::MNT6_298;
 use ark_mnt6_753::MNT6_753;
 
-use ark_nonnative_field::{NonNativeFieldVar, AllocatedNonNativeFieldVar};
+use ark_nonnative_field::{AllocatedNonNativeFieldVar, NonNativeFieldVar};
 use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::FieldVar, R1CSVar};
 use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
 use ark_std::rand::RngCore;
@@ -39,11 +39,12 @@ fn allocation_test<TargetField: PrimeField, BaseField: PrimeField, R: RngCore>(
         "allocated value does not equal the expected value"
     );
 
-    let (_a, a_bits) = AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_witness_with_le_bits(
-        ark_relations::ns!(cs, "alloc a2"),
-        || Ok(a_native),
-    )
-    .unwrap();
+    let (_a, a_bits) =
+        AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_witness_with_le_bits(
+            ark_relations::ns!(cs, "alloc a2"),
+            || Ok(a_native),
+        )
+        .unwrap();
 
     let a_bits_actual: Vec<bool> = a_bits.into_iter().map(|b| b.value().unwrap()).collect();
     let mut a_bits_expected = a_native.into_repr().to_bits_le();

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -1,13 +1,18 @@
 use ark_bls12_381::Bls12_381;
 use ark_ec::PairingEngine;
-use ark_ff::{PrimeField, BigInteger};
+use ark_ff::{BigInteger, PrimeField};
 use ark_mnt4_298::MNT4_298;
 use ark_mnt4_753::MNT4_753;
 use ark_mnt6_298::MNT6_298;
 use ark_mnt6_753::MNT6_753;
 
-use ark_nonnative_field::{NonNativeFieldVar, AllocatedNonNativeFieldVar};
-use ark_r1cs_std::{alloc::{AllocVar, AllocationMode}, eq::EqGadget, fields::FieldVar, R1CSVar};
+use ark_nonnative_field::{AllocatedNonNativeFieldVar, NonNativeFieldVar};
+use ark_r1cs_std::{
+    alloc::{AllocVar, AllocationMode},
+    eq::EqGadget,
+    fields::FieldVar,
+    R1CSVar,
+};
 use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
 use ark_std::rand::RngCore;
 
@@ -39,19 +44,19 @@ fn allocation_test<TargetField: PrimeField, BaseField: PrimeField, R: RngCore>(
         "allocated value does not equal the expected value"
     );
 
-    let (_a, a_bits) = AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_variable_alloc_le_bits(
-        ark_relations::ns!(cs, "alloc a2"),
-        || Ok(a_native),
-        AllocationMode::Witness,
-    )
-    .unwrap();
+    let (_a, a_bits) =
+        AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_variable_alloc_le_bits(
+            ark_relations::ns!(cs, "alloc a2"),
+            || Ok(a_native),
+            AllocationMode::Witness,
+        )
+        .unwrap();
 
     let a_bits_actual: Vec<bool> = a_bits.into_iter().map(|b| b.value().unwrap()).collect();
     let mut a_bits_expected = a_native.into_repr().to_bits_le();
     a_bits_expected.truncate(TargetField::size_in_bits());
     assert_eq!(
-        a_bits_actual,
-        a_bits_expected,
+        a_bits_actual, a_bits_expected,
         "allocated bits does not equal the expected bits"
     );
 }

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -1,13 +1,13 @@
 use ark_bls12_381::Bls12_381;
 use ark_ec::PairingEngine;
-use ark_ff::PrimeField;
+use ark_ff::{PrimeField, BigInteger};
 use ark_mnt4_298::MNT4_298;
 use ark_mnt4_753::MNT4_753;
 use ark_mnt6_298::MNT6_298;
 use ark_mnt6_753::MNT6_753;
 
-use ark_nonnative_field::NonNativeFieldVar;
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::FieldVar, R1CSVar};
+use ark_nonnative_field::{NonNativeFieldVar, AllocatedNonNativeFieldVar};
+use ark_r1cs_std::{alloc::{AllocVar, AllocationMode}, eq::EqGadget, fields::FieldVar, R1CSVar};
 use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
 use ark_std::rand::RngCore;
 
@@ -37,6 +37,22 @@ fn allocation_test<TargetField: PrimeField, BaseField: PrimeField, R: RngCore>(
     assert!(
         a_actual.eq(&a_expected),
         "allocated value does not equal the expected value"
+    );
+
+    let (_a, a_bits) = AllocatedNonNativeFieldVar::<TargetField, BaseField>::new_variable_alloc_le_bits(
+        ark_relations::ns!(cs, "alloc a2"),
+        || Ok(a_native),
+        AllocationMode::Witness,
+    )
+    .unwrap();
+
+    let a_bits_actual: Vec<bool> = a_bits.into_iter().map(|b| b.value().unwrap()).collect();
+    let mut a_bits_expected = a_native.into_repr().to_bits_le();
+    a_bits_expected.truncate(TargetField::size_in_bits());
+    assert_eq!(
+        a_bits_actual,
+        a_bits_expected,
+        "allocated bits does not equal the expected bits"
     );
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When doing nonnative arithmetic, bit-allocating witnesses requires a non-trivial number of constraints. This PR adds an allocation function which also returns the bits, instead of just dropping them. That way if you need the bits, you don't have to duplicate constraints.

Motivation: In a recent circuit, I wanted to (a) bit-allocate some non-native field elements (b) do some simple (and cheap!) math on them and (c) do some other stuff with the bits. It seemed that bit-allocation would actually be a bottleneck here, so de-duplicating that work was important. Figured I'd submit the patch upstream, in case you wanted it.

Design: Basically I just moved the allocation code to a new fn that exposes the bits, and had the original allocation function call the new one.

P.S. Thanks for putting this library together. It's very nice to not have to roll my own multiprecision machinery again :)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer